### PR TITLE
Disable 'ssh_args', add '/lib32' to exlude list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.1.5
+------
+
+*Released: 2015-04-30*
+
+- Add ``/lib32`` directory to the list of default excluded directories.
+  [drybjed]
+
 v0.1.4
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ v0.1.5
 - Add ``/lib32`` directory to the list of default excluded directories.
   [drybjed]
 
+- Disable ``ssh_args`` setting on Debian Jessie due to `Debian Bug #717451`_ to
+  allow backups to run. It will be re-enabled when a fix is released in future
+  Jessie point release. [drybjed]
+
+.. _Debian Bug #717451: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717451
+
 v0.1.4
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,6 +182,7 @@ rsnapshot_exclude_default: |
   - /cdrom
   - /dev
   - /lib
+  - /lib32
   - /lib64
   - /media
   - /mnt

--- a/templates/etc/rsnapshot/external-server/rsnapshot.conf.j2
+++ b/templates/etc/rsnapshot/external-server/rsnapshot.conf.j2
@@ -177,7 +177,15 @@ lockfile	/var/run/rsnapshot-{{ rsnapshot_tpl_host }}.pid
 
 # ssh has no args passed by default, but you can specify some here.
 #
+{% if ansible_distribution == 'Debian' and ansible_distribution_release == 'jessie' %}
+# In Debian Jessie, rsnapshot has a bug related to 'ssh_args' option,
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717451
+# Until a bugfix is released, 'ssh_args' option is disabled by default to allow
+# for backups to be processed
+#ssh_args	{{ host.ssh_args | default(rsnapshot_ssh_args | default("-p 22")) }}
+{% else %}
 ssh_args	{{ host.ssh_args | default(rsnapshot_ssh_args | default("-p 22")) }}
+{% endif %}
 
 # Default arguments for the "du" program (for disk space reporting).
 # The GNU version of "du" is preferred. See the man page for more details.

--- a/templates/etc/rsnapshot/server/rsnapshot.conf.j2
+++ b/templates/etc/rsnapshot/server/rsnapshot.conf.j2
@@ -184,7 +184,15 @@ lockfile	/var/run/rsnapshot-{{ rsnapshot_tpl_host }}.pid
 
 # ssh has no args passed by default, but you can specify some here.
 #
+{% if ansible_distribution == 'Debian' and ansible_distribution_release == 'jessie' %}
+# In Debian Jessie, rsnapshot has a bug related to 'ssh_args' option,
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717451
+# Until a bugfix is released, 'ssh_args' option is disabled by default to allow
+# for backups to be processed
+#ssh_args	{{ host.rsnapshot_ssh_args | default(rsnapshot_ssh_args | default("-p 22")) }}
+{% else %}
 ssh_args	{{ host.rsnapshot_ssh_args | default(rsnapshot_ssh_args | default("-p 22")) }}
+{% endif %}
 
 # Default arguments for the "du" program (for disk space reporting).
 # The GNU version of "du" is preferred. See the man page for more details.


### PR DESCRIPTION
- Add ``/lib32`` directory to the list of default excluded directories.

- Disable ``ssh_args`` setting on Debian Jessie due to [Debian Bug #717451](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717451) to allow backups to run. It will be re-enabled when a fix is released in future Jessie point release.