### PR TITLE
Bypass issues with vanishing files during backups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+v0.1.6
+------
+
+*Released: 2015-06-11*
+
+- Add ``rsnapshot_cmd_rsync`` variable which allows you to set the path to
+  a script executed during backup. [drybjed]
+
+- Add ``rsync-no-vanished`` wrapper script, which bypasses an issue when `files
+  during long backups vanish`_ and the backup cycle is broken. It's set to be
+  run by default for all hosts, can be overriden per host. [drybjed]
+
+.. _files during long backups vanish: https://bugzilla.samba.org/show_bug.cgi?id=3653
+
 v0.1.5
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,12 @@ rsnapshot_external_servers: []
 rsnapshot_snapshot_root: '/var/cache/rsnapshot'
 
 
+# .. envvar:: rsnapshot_cmd_rsync
+#
+# Main script executed by ``rsnapshot`` script to perform backups
+rsnapshot_cmd_rsync: '/usr/local/lib/rsync-no-vanished'
+
+
 # .. envvar:: rsnapshot_link_dest
 #
 # Enable --link-dest option in rsync commands

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,15 @@
     install_recommends: False
   when: inventory_hostname in rsnapshot_clients
 
+- name: Install rsync-no-vanished script
+  template:
+    src: 'usr/local/lib/rsync-no-vanished.j2'
+    dest: '{{ ansible_local.root.lib + "/rsync-no-vanished" }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: inventory_hostname in rsnapshot_clients
+
 - name: Enforce rsnapshot root directory permissions
   file:
     path: '{{ rsnapshot_snapshot_root }}'

--- a/templates/etc/rsnapshot/external-server/rsnapshot.conf.j2
+++ b/templates/etc/rsnapshot/external-server/rsnapshot.conf.j2
@@ -68,7 +68,11 @@ cmd_cp		/bin/cp
 # rsync must be enabled for anything to work. This is the only command that
 # must be enabled.
 #
-cmd_rsync	/usr/bin/rsync
+{% if (host.cmd_rsync is defined and host.cmd_rsync) %}
+cmd_rsync	{{ host.cmd_rsync }}
+{% elif host.cmd_rsync is undefined %}
+cmd_rsync	{{ rsnapshot_cmd_rsync }}
+{% endif %}
 
 # Uncomment this to enable remote ssh backups over rsync.
 #

--- a/templates/etc/rsnapshot/server/rsnapshot.conf.j2
+++ b/templates/etc/rsnapshot/server/rsnapshot.conf.j2
@@ -75,7 +75,11 @@ cmd_cp		/bin/cp
 # rsync must be enabled for anything to work. This is the only command that
 # must be enabled.
 #
-cmd_rsync	/usr/bin/rsync
+{% if (host.cmd_rsync is defined and host.cmd_rsync) %}
+cmd_rsync	{{ host.cmd_rsync }}
+{% elif host.cmd_rsync is undefined %}
+cmd_rsync	{{ rsnapshot_cmd_rsync }}
+{% endif %}
 
 # Uncomment this to enable remote ssh backups over rsync.
 #

--- a/templates/usr/local/lib/rsync-no-vanished.j2
+++ b/templates/usr/local/lib/rsync-no-vanished.j2
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+
+# Use this script instead of /usr/bin/rsync command to avoid issues with
+# vanishing files.
+# https://bugzilla.samba.org/show_bug.cgi?id=3653
+
+IGNOREEXIT=24
+IGNOREOUT='^(file has vanished: |rsync warning: some files vanished before they could be transferred)'
+
+set -o pipefail
+
+rsync "${@}" 2>&1 | (egrep -v "$IGNOREOUT" || true)
+ret=$?
+
+if [[ $ret == $IGNOREEXIT ]]; then
+    ret=0
+fi
+
+exit $ret


### PR DESCRIPTION
Add 'rsnapshot_cmd_rsync' variable which allows you to set the path to
a script executed during backup.

Add 'rsync-no-vanished' wrapper script, which bypasses an issue when
`files during long backups vanish`_ and the backup cycle is broken. It's
set to be run by default for all hosts, can be overriden per host.