### PR TITLE
Fixed ansible_managed because it is not default of the DebOps project.

### DIFF
--- a/templates/etc/cron/rsnapshot-wrapper.j2
+++ b/templates/etc/cron/rsnapshot-wrapper.j2
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 # Launch rsnapshot {{ item }} backups
 test -x {{ ansible_local.root.lib }}/rsnapshot-cron-wrapper && {{ ansible_local.root.lib }}/rsnapshot-cron-wrapper {{ item }} || true

--- a/templates/etc/logrotate.d/rsnapshot.j2
+++ b/templates/etc/logrotate.d/rsnapshot.j2
@@ -1,4 +1,4 @@
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 /var/log/rsnapshot.log /var/log/rsnapshot/*.log {
 	rotate 6

--- a/templates/etc/rsnapshot/external-server/exclude.txt.j2
+++ b/templates/etc/rsnapshot/external-server/exclude.txt.j2
@@ -1,5 +1,5 @@
 {% set host = item.0 %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 {% if host.exclude is defined and host.exclude %}
 {% set rsnapshot_tpl_exclude = host.exclude %}

--- a/templates/etc/rsnapshot/external-server/include.txt.j2
+++ b/templates/etc/rsnapshot/external-server/include.txt.j2
@@ -1,5 +1,5 @@
 {% set host = item.0 %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 {% if host.include is defined and host.include %}
 {% set rsnapshot_tpl_include = host.include %}

--- a/templates/etc/rsnapshot/external-server/rsnapshot.conf.j2
+++ b/templates/etc/rsnapshot/external-server/rsnapshot.conf.j2
@@ -14,7 +14,7 @@
 {% else %}
 {% set rsnapshot_tpl_path = '/' %}
 {% endif %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 #################################################
 # rsnapshot.conf - rsnapshot configuration file #

--- a/templates/etc/rsnapshot/external-server/runner.j2
+++ b/templates/etc/rsnapshot/external-server/runner.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 {% set host = item.0 %}
 
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 currenttype="${1:-hourly}"
 prevtype="${2:-null}"

--- a/templates/etc/rsnapshot/server/exclude.txt.j2
+++ b/templates/etc/rsnapshot/server/exclude.txt.j2
@@ -1,5 +1,5 @@
 {% set host = hostvars[item.0] %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 {% if host.rsnapshot_exclude is defined and host.rsnapshot_exclude %}
 {% set rsnapshot_tpl_exclude = host.rsnapshot_exclude %}

--- a/templates/etc/rsnapshot/server/include.txt.j2
+++ b/templates/etc/rsnapshot/server/include.txt.j2
@@ -1,5 +1,5 @@
 {% set host = hostvars[item.0] %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 {% if host.rsnapshot_include is defined and host.rsnapshot_include %}
 {% set rsnapshot_tpl_include = host.rsnapshot_include %}

--- a/templates/etc/rsnapshot/server/rsnapshot.conf.j2
+++ b/templates/etc/rsnapshot/server/rsnapshot.conf.j2
@@ -21,7 +21,7 @@
 {% else %}
 {% set rsnapshot_tpl_uuid = '' %}
 {% endif %}
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 #################################################
 # rsnapshot.conf - rsnapshot configuration file #

--- a/templates/etc/rsnapshot/server/runner.j2
+++ b/templates/etc/rsnapshot/server/runner.j2
@@ -6,7 +6,7 @@
 {% set rsnapshot_tpl_host = host.ansible_fqdn %}
 {% endif %}
 
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 currenttype="${1:-hourly}"
 prevtype="${2:-null}"

--- a/templates/usr/local/lib/rsnapshot-cron-wrapper.j2
+++ b/templates/usr/local/lib/rsnapshot-cron-wrapper.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This file is managed remotely, all changes will be lost
+# {{ ansible_managed }}
 
 # This script should be executed from cron with a parameter, for example:
 # @hourly   root rsnapshot-cron-wrapper hourly


### PR DESCRIPTION
* Would not be found be https://github.com/debops/debops/issues/120
* `git ls-files | xargs sed -i 's/This file is managed remotely, all changes will be lost/{{ ansible_managed }}/'`