### PR TITLE
Adds explicit jinja2 wrapping for ansible 2.2

### DIFF
--- a/tasks/configure_ssh_keys.yml
+++ b/tasks/configure_ssh_keys.yml
@@ -25,7 +25,7 @@
     key_options: 'no-pty,no-agent-forwarding,no-X11-forwarding,no-port-forwarding,command="{{ hostvars[item].rsnapshot_ssh_command if (hostvars[item].rsnapshot_ssh_command|d() and hostvars[item].rsnapshot_ssh_command|bool) else rsnapshot_ssh_command }}"'
     state: 'present'
   delegate_to: '{{ item }}'
-  with_items: rsnapshot_servers
+  with_items: '{{ rsnapshot_servers }}'
   when: ((item is defined and item) and item != inventory_hostname and
          hostvars[item].ansible_hostname is defined)
 
@@ -37,12 +37,12 @@
 
 - name: Remove known host fingerprints from ~/.ssh/known_hosts
   shell: ssh-keygen -f /root/.ssh/known_hosts -R {{ hostvars[item].rsnapshot_backup_host if (hostvars[item].rsnapshot_backup_host|d() and hostvars[item].rsnapshot_backup_host|bool) else hostvars[item].ansible_fqdn }}
-  with_items: rsnapshot_servers
+  with_items: '{{ rsnapshot_servers }}'
   when: rsnapshot_reset_sshkeys is defined and rsnapshot_reset_sshkeys
 
 - name: Get list of already scanned host fingerprints
   shell: ssh-keygen -f /root/.ssh/known_hosts -F {{ hostvars[item].rsnapshot_backup_host if (hostvars[item].rsnapshot_backup_host|d() and hostvars[item].rsnapshot_backup_host|bool) else hostvars[item].ansible_fqdn }} | grep -q '^# Host {{ hostvars[item].rsnapshot_backup_host if (hostvars[item].rsnapshot_backup_host|d() and hostvars[item].rsnapshot_backup_host|bool) else hostvars[item].ansible_fqdn }} found'
-  with_items: rsnapshot_servers
+  with_items: '{{ rsnapshot_servers }}'
   when: ((item is defined and item) and item != inventory_hostname and
          hostvars[item].ansible_fqdn is defined)
   register: rsnapshot_register_known_hosts
@@ -51,13 +51,13 @@
 
 - name: Scan SSH fingerprints of rsnapshot servers with custom hostname
   shell: 'ssh-keyscan -H -T 10 -p {{ hostvars[item].rsnapshot_ssh_port if (hostvars[item].rsnapshot_ssh_port|d() and hostvars[item].rsnapshot_ssh_port) else rsnapshot_ssh_port }} {{ hostvars[item].rsnapshot_backup_host }} >> /root/.ssh/known_hosts'
-  with_items: rsnapshot_register_known_hosts.results
+  with_items: '{{ rsnapshot_register_known_hosts.results }}'
   when: ((item is defined and item.rc > 0) and
          (item.rsnapshot_backup_host is defined and item.rsnapshot_backup_host))
 
 - name: Scan SSH fingerprints of rsnapshot servers
   shell: 'ssh-keyscan -H -T 10 -p {{ hostvars[item.item].rsnapshot_ssh_port if (hostvars[item.item].rsnapshot_ssh_port|d() and hostvars[item.item].rsnapshot_ssh_port) else rsnapshot_ssh_port }} {{ hostvars[item.item].ansible_fqdn }} >> /root/.ssh/known_hosts'
-  with_items: rsnapshot_register_known_hosts.results
+  with_items: '{{ rsnapshot_register_known_hosts.results }}'
   when: item is defined and item.rc > 0
 
 - name: Check if ~/.profile file exists on root account
@@ -65,7 +65,7 @@
     path: ~/.profile
   register: rsnapshot_register_root_profile
   delegate_to: '{{ item }}'
-  with_items: rsnapshot_servers
+  with_items: '{{ rsnapshot_servers }}'
   when: ((item is defined and item) and item != inventory_hostname and
          hostvars[item].ansible_hostname is defined)
 
@@ -78,8 +78,8 @@
     create: 'no'
   delegate_to: '{{ item.0 }}'
   with_together:
-    - rsnapshot_servers
-    - rsnapshot_register_root_profile.results
+    - '{{ rsnapshot_servers }}'
+    - '{{ rsnapshot_register_root_profile.results }}'
   when: (((item.0 is defined and item.0) and item.0 != inventory_hostname and
           hostvars[item.0].ansible_hostname is defined) and
          (item.1 is defined and item.1.stat.exists))

--- a/tasks/external_servers.yml
+++ b/tasks/external_servers.yml
@@ -7,7 +7,7 @@
     owner: 'root'
     group: 'root'
     mode: '0755'
-  with_items: rsnapshot_external_servers
+  with_items: '{{ rsnapshot_external_servers }}'
   when: (inventory_hostname in rsnapshot_clients and
          ((item is defined and item) and item != inventory_hostname and
           item.name is defined))
@@ -35,13 +35,13 @@
 
 - name: Remove known host fingerprints from ~/.ssh/known_hosts
   shell: ssh-keygen -f /root/.ssh/known_hosts -R {{ hostvars[item].rsnapshot_backup_host if (hostvars[item].rsnapshot_backup_host|d() and hostvars[item].rsnapshot_backup_host|bool) else hostvars[item].ansible_fqdn }}
-  with_items: rsnapshot_external_servers
+  with_items: '{{ rsnapshot_external_servers }}'
   when: rsnapshot_reset_sshkeys is defined and rsnapshot_reset_sshkeys
   tags: [ 'role::rsnapshot:sshkeys' ]
 
 - name: Get list of already scanned host fingerprints
   shell: ssh-keygen -f /root/.ssh/known_hosts -F {{ item.backup_host | default(item.name) }} | grep -q '^# Host {{ item.backup_host | default(item.name) }} found'
-  with_items: rsnapshot_external_servers
+  with_items: '{{ rsnapshot_external_servers }}'
   when: (inventory_hostname in rsnapshot_clients and
          ((item is defined and item) and item != inventory_hostname and
           item.name is defined))
@@ -52,14 +52,14 @@
 
 - name: Scan SSH fingerprints of rsnapshot servers with custom hostname
   shell: 'ssh-keyscan -H -T 10 -p {{ item.item.ssh_port | d(rsnapshot_ssh_port) }} {{ item.backup_host }} >> /root/.ssh/known_hosts'
-  with_items: rsnapshot_register_external_known_hosts.results
+  with_items: '{{ rsnapshot_register_external_known_hosts.results }}'
   when: ((item is defined and item.rc > 0) and
          (item.backup_host is defined and item.backup_host))
   tags: [ 'role::rsnapshot:sshkeys' ]
 
 - name: Scan SSH fingerprints of rsnapshot servers
   shell: 'ssh-keyscan -H -T 10 -p {{ item.item.ssh_port | d(rsnapshot_ssh_port) }} {{ item.item.name }} >> /root/.ssh/known_hosts'
-  with_items: rsnapshot_register_external_known_hosts.results
+  with_items: '{{ rsnapshot_register_external_known_hosts.results }}'
   when: item is defined and item.rc > 0
   tags: [ 'role::rsnapshot:sshkeys' ]
 

--- a/tasks/external_servers.yml
+++ b/tasks/external_servers.yml
@@ -20,7 +20,7 @@
     group: 'root'
     mode: '0644'
   with_nested:
-    - rsnapshot_external_servers
+    - '{{ rsnapshot_external_servers }}'
     - [ 'include.txt', 'exclude.txt', 'rsnapshot.conf' ]
   when: (inventory_hostname in rsnapshot_clients and
          ((item.0 is defined and item.0) and item.0 != inventory_hostname and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,7 +75,7 @@
     owner: 'root'
     group: 'root'
     mode: '0755'
-  with_items: rsnapshot_servers
+  with_items: '{{ rsnapshot_servers }}'
   when: (inventory_hostname in rsnapshot_clients and
          ((item is defined and item) and item != inventory_hostname and
           item not in rsnapshot_clients and hostvars[item].ansible_fqdn is defined))
@@ -91,7 +91,7 @@
     group: 'root'
     mode: '0644'
   with_nested:
-    - rsnapshot_servers
+    - '{{ rsnapshot_servers }}'
     - [ 'include.txt', 'exclude.txt', 'rsnapshot.conf' ]
   when: (inventory_hostname in rsnapshot_clients and
          ((item.0 is defined and item.0) and item.0 != inventory_hostname and


### PR DESCRIPTION
Fixes:

``
TASK [debops.rsnapshot : Scan SSH fingerprints of rsnapshot servers with custom hostname] *************************************************************************************************************************
fatal: [backup]: FAILED! => {"failed": true, "msg": "The conditional check '((item is defined and item.rc > 0) and (item.backup_host is defined and item.backup_host))' failed. The error was: error while evaluating conditional (((item is defined and item.rc > 0) and (item.backup_host is defined and item.backup_host))): 'ansible.vars.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'rc'\n\nThe error appears to have been in '/home/gomez/.local/share/debops/debops-playbooks/roles/debops.rsnapshot/tasks/external_servers.yml': line 53, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Scan SSH fingerprints of rsnapshot servers with custom hostname\n  ^ here\n"}
``
